### PR TITLE
[feat]: [CI-12621]: Update drone-buildx version for DLC Savings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gcr
 go 1.21
 
 require (
-	github.com/drone-plugins/drone-buildx v1.1.1
+	github.com/drone-plugins/drone-buildx v1.1.6
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/oauth2 v0.19.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gcr
 go 1.21
 
 require (
-	github.com/drone-plugins/drone-buildx v1.1.6
+	github.com/drone-plugins/drone-buildx v1.1.7
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/oauth2 v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.1.1 h1:apPCqcE36Dbkn8ZEquN72MGAEEfXchm00lEyyaDrmFY=
-github.com/drone-plugins/drone-buildx v1.1.1/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
+github.com/drone-plugins/drone-buildx v1.1.6 h1:ko4SHehxSu+8B1hPbIHhDhf2uvB4S+qRzaG1R6FXlcg=
+github.com/drone-plugins/drone-buildx v1.1.6/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.1.6 h1:ko4SHehxSu+8B1hPbIHhDhf2uvB4S+qRzaG1R6FXlcg=
-github.com/drone-plugins/drone-buildx v1.1.6/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
+github.com/drone-plugins/drone-buildx v1.1.7 h1:v++Lb1xJ5pAyN/Mo+NZFtuDLvyWRdGM+LgzuSsArHqU=
+github.com/drone-plugins/drone-buildx v1.1.7/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
Cache metrics being successfully written, parsed and uploaded to ti-service

<img width="1662" alt="Screenshot 2024-05-31 at 2 03 26 PM" src="https://github.com/drone-plugins/drone-buildx-gcr/assets/114451080/ded1ed59-43c6-4b49-8153-237247dbb663">
<img width="1662" alt="Screenshot 2024-05-31 at 2 03 34 PM" src="https://github.com/drone-plugins/drone-buildx-gcr/assets/114451080/a47827d8-a765-41c4-952d-4c341d7ae498">
<img width="1699" alt="Screenshot 2024-05-31 at 2 04 45 PM" src="https://github.com/drone-plugins/drone-buildx-gcr/assets/114451080/16906859-e16e-44de-b903-0a5e9584d887">
