### PR TITLE
upgrade buildx base plugin version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gcr
 go 1.21
 
 require (
-	github.com/drone-plugins/drone-buildx v1.1.14
+	github.com/drone-plugins/drone-buildx v1.1.15
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/oauth2 v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.1.14 h1:t+z65snQQmmgd9w3QmHXXm0k/BrVQKq/fR31aHLLABc=
-github.com/drone-plugins/drone-buildx v1.1.14/go.mod h1:TR1qqwMYXpe38qHb7am2FFIF/Y0yRucen9BMv35AR00=
+github.com/drone-plugins/drone-buildx v1.1.15 h1:Mc5jpu5MCaU8C57x9VbRwdDyN0ft9HYx6TyjGckZTz8=
+github.com/drone-plugins/drone-buildx v1.1.15/go.mod h1:TR1qqwMYXpe38qHb7am2FFIF/Y0yRucen9BMv35AR00=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
Base buildx plugin PR : https://github.com/drone-plugins/drone-buildx/pull/34

Here the ask was to validate anonymous connector on save, but we want to minimize validations on save for efficiency. The other ask was for a proper error message in case anonymous connector is used as base image connector, but since this pull would be successful even without the connector we are throwing a suggestive error.