### PR TITLE
upgrade buildx version to support docker secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/drone-plugins/drone-buildx-gcr
 go 1.21
 
 require (
-	github.com/drone-plugins/drone-buildx v1.1.17
+	github.com/drone-plugins/drone-buildx v1.1.18
 	github.com/joho/godotenv v1.5.1
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/oauth2 v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.1.16 h1:sQJZ3ujgUElghUapT+r2G1ts1w6ckoHjXwcv5GvzMak=
-github.com/drone-plugins/drone-buildx v1.1.16/go.mod h1:TR1qqwMYXpe38qHb7am2FFIF/Y0yRucen9BMv35AR00=
-github.com/drone-plugins/drone-buildx v1.1.17 h1:OOmu0KN9YaQGOFLv3RqSlEsl8hyI8EqZi156zQ0rins=
-github.com/drone-plugins/drone-buildx v1.1.17/go.mod h1:TR1qqwMYXpe38qHb7am2FFIF/Y0yRucen9BMv35AR00=
+github.com/drone-plugins/drone-buildx v1.1.18 h1:+yhLkgcBP/kkPjtpm33GC83LbTCYTG0Ob8fLaRxBrrs=
+github.com/drone-plugins/drone-buildx v1.1.18/go.mod h1:TR1qqwMYXpe38qHb7am2FFIF/Y0yRucen9BMv35AR00=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
Allow docker secrets via environment var and harness secret types to be used in buildx plugin at build time.

Testing: Dockerfile shows docker secret via env (docker_user) and harness_secret (docker_pass) to be used in a docker login command at run-time.
https://github.com/drone-plugins/drone-buildx/pull/40