### PR TITLE
[CI-21701]: Upgrade Go version to fix EOL stdlib vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/drone-plugins/drone-buildx-gcr
 
-go 1.24.11
-
-toolchain go1.25.5
+go 1.26.0
 
 require (
 	github.com/drone-plugins/drone-buildx v1.3.15


### PR DESCRIPTION
Upgraded Go version from go1.24.11 to go1.26.0 to address the following EOL components reported in image plugins/buildx-gcr:1.4.4:

- stdlib go1.24.11 (EOL: 2026-02-11)
- stdlib go1.24.3  (EOL: 2026-02-11)
- stdlib go1.23.8  (EOL: 2025-08-12)

Go 1.24 reached end-of-life on February 11, 2026 when Go 1.26 was released. Per Go's support policy, only the two most recent major releases are maintained. Go 1.26.0 is the current stable release and is actively supported.

The toolchain directive has been consolidated into the single 'go 1.26.0' directive, removing the separate 'toolchain go1.25.5' line.

go mod tidy was run to verify dependency compatibility. All modules verified.

AI-Session-Id: c6e32c28-3efe-40d8-babc-3ddd1af573bf
AI-Tool: claude-code
AI-Model: global.anthropic.claude-sonnet-4-6