### PR TITLE
feat: [CI-23661]: windows 2025 support

### DIFF
--- a/docker/gcr/Dockerfile.windows.amd64.ltsc2025
+++ b/docker/gcr/Dockerfile.windows.amd64.ltsc2025
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-ltsc2025-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone GCR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-gcr.exe C:/bin/buildx-gcr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-gcr.exe" ]

--- a/docker/gcr/manifest.tmpl
+++ b/docker/gcr/manifest.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/buildx-gcr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (LTSC) to the GCR Buildx plugin. The main changes include introducing a new Dockerfile and updating the manifest to include the new platform.

**Windows Server 2025 (LTSC) support:**

* Added a new Dockerfile `docker/gcr/Dockerfile.windows.amd64.ltsc2025` to build the plugin for the Windows Server 2025 (LTSC) amd64 platform.
* Updated the manifest file `docker/gcr/manifest.tmpl` to include an entry for the new Windows Server 2025 (LTSC) amd64 image.